### PR TITLE
Fix JustSwap correct link

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,7 +422,7 @@
                         <div class="column">
                             <p class="has-text-weight-normal icon-text">
                                 <img class="icon" alt="JustSwap" src="assets/justswap.png">
-                                <a href="https://justswap.io/#/scan/detail/trx/TWYaXdxA12JywrUdou3PFD1fvx2PWjqK9U" target="_blank">
+                                <a href="https://justswap.io/#/scan/detail/TWYaXdxA12JywrUdou3PFD1fvx2PWjqK9U" target="_blank">
                                     <span>
                                         <span class="has-text-weight-bold">Just Swap</span>
                                     </span>


### PR DESCRIPTION
The actual link opens a empty swap. Corrected it

![image](https://user-images.githubusercontent.com/532372/153514166-85b67a04-3928-44e6-b410-425129e3cbfa.png)
